### PR TITLE
WIP: fix typos in the documentation

### DIFF
--- a/tutorials/basicprocessing_multigauss/basicprocessing_multigauss.html
+++ b/tutorials/basicprocessing_multigauss/basicprocessing_multigauss.html
@@ -51,12 +51,12 @@ r = time2dist(traw);
 
 %Optimization & Correction of phase
 V = correctphase(Vraw);
-%Optimization & Correctionof zero-time
+%Optimization & Correction of zero-time
 t = correctzerotime(V,traw);
 %Optimization & Correction of Y-axis scale
 V = correctscale(V,t);
 %% Prepare the dipolar kernel
-% Since experimental dipolar signals contain a inter-molecular contribution, 
+% Since experimental dipolar signals contain an inter-molecular contribution, 
 % i.e. a background, this must be fitted and included into the dipolar kernel 
 % before the regularization.
 % 


### PR DESCRIPTION
Fixing a few typos in the documentation.

Recreated pull request after branching from `DeerLab\develop` and not `DeerLab\master` (#33) , as there was a significant change in the documentation backend.